### PR TITLE
Add button to delete all entries in datastore

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -1,0 +1,26 @@
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+
+@WebServlet("/delete-data")
+public class DeleteServlet extends HttpServlet {
+   @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query("Comment");
+    PreparedQuery results = datastore.prepare(query);
+    
+    for (Entity entity : results.asIterable()) {
+      datastore.delete(entity.getKey());
+    }
+    
+    response.sendRedirect("/index.html");
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -58,7 +58,22 @@
         <br>
         <input type="submit"/>
       </form>
+      
+      <p>Max Comments Shown:</p>
+      <select id="numComments">
+        <option name="1"> 1 </option>
+        <option name="2"> 2 </option>
+        <option name="3"> 3 </option>
+        <option name="4"> 4 </option>
+      </select>
+      <button onClick="fetchComments()">Load</button>
 
+
+      <form action="\delete-data" method="POST">
+        <p>Delete all comments</p>
+        <input type="submit"/>
+      </form>
+      
       <div id="data-container"> </div>
     </div>
 


### PR DESCRIPTION
Button on html page to delete all comments in datastore. Final challenge in part 6 of walkthrough. I was talking to Cory and Jack and we couldn't figure out how to use [dataflow](https://cloud.google.com/datastore/docs/bulk-delete) to bulk delete. This uses brute force to delete. I want to update this once we figure out how to use dataflow