### PR TITLE
Return available meeting times for mandatory + optional members

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,98 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Comparator;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+
+    // if meeting only has optional members treat them as mandatory
+    Collection<String> mandatoryMembers = new ArrayList();
+    Collection<String> optionalMembers = new ArrayList();
+    if (request.getAttendees().isEmpty()) {
+      mandatoryMembers = request.getOptionalAttendees();
+    } else {
+      mandatoryMembers = request.getAttendees();
+      optionalMembers = request.getOptionalAttendees(); 
+    }
+
+    ArrayList<TimeRange> unavailableTimes = new ArrayList();   
+    ArrayList<TimeRange> unavailableTimesOptionalMembers = new ArrayList(); 
+    // go through all events and find unavailable times
+    for (Event e : events) {
+      Set<String> attendes = e.getAttendees();
+      for (String s : mandatoryMembers) {
+        if (attendes.contains(s)) {
+          // someone un at time period
+          unavailableTimes.add(e.getWhen());
+          break;
+        }
+      }
+
+      for (String s : optionalMembers) {
+        if (attendes.contains(s)) {
+          // someone optional unavailable at time period
+          unavailableTimesOptionalMembers.add(e.getWhen());
+          break;
+        }
+      }
+    }
+
+    ArrayList<TimeRange> availableTimes = new ArrayList();
+    // stores starting time of available time range
+    int start = 0; 
+    // end of latest time period looked at 
+    int maxEnd = 0;
+
+    Collections.sort(unavailableTimes, TimeRange.ORDER_BY_START);
+    for (TimeRange t : unavailableTimes) {
+      // checks if meeting nested in other - ignore meeting in this case
+      if (t.end() > maxEnd) {
+        maxEnd = t.end();
+      } else {
+        continue;
+      }
+
+      // check time period long enough for meeting
+      if (t.start() - start < request.getDuration()) {
+        start = t.end(); 
+        continue; 
+      }
+
+      // add avaliable time
+      availableTimes.add(TimeRange.fromStartEnd(start, t.start(), false));
+      start = t.end();     
+    }
+
+    // add from start - end check
+    if (TimeRange.END_OF_DAY - start > request.getDuration()) {
+      availableTimes.add(TimeRange.fromStartEnd(start, TimeRange.END_OF_DAY, true));
+    } 
+
+    // handle optional members if presenet
+    if (optionalMembers.isEmpty()) {
+      return availableTimes;
+    }
+
+    // add times where mandatory and optional members not busy  
+    ArrayList<TimeRange> optionalMemberTimes = new ArrayList();
+    for (TimeRange availableTime : availableTimes) {
+      for (TimeRange unavailableOptionalTime : unavailableTimesOptionalMembers) {
+        if (!availableTime.overlaps(unavailableOptionalTime)) {
+          optionalMemberTimes.add(availableTime);
+        }
+      }
+    }
+
+    // if no times work for optional members return all times for mandatory members
+    if (optionalMemberTimes.isEmpty()) {
+      return availableTimes;
+    } else {
+      return optionalMemberTimes;
+    }
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -24,9 +24,10 @@ import java.util.Comparator;
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
 
-    // if meeting only has optional members treat them as mandatory
     Collection<String> mandatoryMembers = new ArrayList();
     Collection<String> optionalMembers = new ArrayList();
+
+    // if meeting only has optional members treat them as mandatory
     if (request.getAttendees().isEmpty()) {
       mandatoryMembers = request.getOptionalAttendees();
     } else {
@@ -34,73 +35,20 @@ public final class FindMeetingQuery {
       optionalMembers = request.getOptionalAttendees(); 
     }
 
-    ArrayList<TimeRange> unavailableTimes = new ArrayList();   
-    ArrayList<TimeRange> unavailableTimesOptionalMembers = new ArrayList(); 
     // go through all events and find unavailable times
-    for (Event e : events) {
-      Set<String> attendes = e.getAttendees();
-      for (String s : mandatoryMembers) {
-        if (attendes.contains(s)) {
-          // someone un at time period
-          unavailableTimes.add(e.getWhen());
-          break;
-        }
-      }
+    ArrayList<TimeRange> unavailableTimes = findUnavailableTimesMandatoryAttendees(events, mandatoryMembers);   
 
-      for (String s : optionalMembers) {
-        if (attendes.contains(s)) {
-          // someone optional unavailable at time period
-          unavailableTimesOptionalMembers.add(e.getWhen());
-          break;
-        }
-      }
-    }
-
-    ArrayList<TimeRange> availableTimes = new ArrayList();
-    // stores starting time of available time range
-    int start = 0; 
-    // end of latest time period looked at 
-    int maxEnd = 0;
-
-    Collections.sort(unavailableTimes, TimeRange.ORDER_BY_START);
-    for (TimeRange t : unavailableTimes) {
-      // checks if meeting nested in other - ignore meeting in this case
-      if (t.end() > maxEnd) {
-        maxEnd = t.end();
-      } else {
-        continue;
-      }
-
-      // check time period long enough for meeting
-      if (t.start() - start < request.getDuration()) {
-        start = t.end(); 
-        continue; 
-      }
-
-      // add avaliable time
-      availableTimes.add(TimeRange.fromStartEnd(start, t.start(), false));
-      start = t.end();     
-    }
-
-    // add from start - end check
-    if (TimeRange.END_OF_DAY - start > request.getDuration()) {
-      availableTimes.add(TimeRange.fromStartEnd(start, TimeRange.END_OF_DAY, true));
-    } 
-
-    // handle optional members if presenet
+    // find available times from unavilable times from mandatory members
+    ArrayList<TimeRange> availableTimes = findAvalibaleTimesMandatoryMembers(unavailableTimes, request);
+    
+    // handle optional members if present
     if (optionalMembers.isEmpty()) {
       return availableTimes;
     }
-
+    
     // add times where mandatory and optional members not busy  
-    ArrayList<TimeRange> optionalMemberTimes = new ArrayList();
-    for (TimeRange availableTime : availableTimes) {
-      for (TimeRange unavailableOptionalTime : unavailableTimesOptionalMembers) {
-        if (!availableTime.overlaps(unavailableOptionalTime)) {
-          optionalMemberTimes.add(availableTime);
-        }
-      }
-    }
+    ArrayList<TimeRange> unavailableTimesOptionalMembers = findUnavailableTimesOptionalAttendees(events, optionalMembers); 
+    ArrayList<TimeRange> optionalMemberTimes = findTimeWithOptionalMembers(availableTimes, unavailableTimesOptionalMembers);
 
     // if no times work for optional members return all times for mandatory members
     if (optionalMemberTimes.isEmpty()) {
@@ -108,5 +56,85 @@ public final class FindMeetingQuery {
     } else {
       return optionalMemberTimes;
     }
+  }
+
+  // finds unavailable times for list of mandatory attendees 
+  public ArrayList<TimeRange> findUnavailableTimesMandatoryAttendees(Collection<Event> events, Collection<String> mandatoryMembers) {
+    ArrayList<TimeRange> unavailableTimes = new ArrayList();
+    for (Event e : events) {
+      Set<String> attendes = e.getAttendees();
+      for (String s : mandatoryMembers) {
+        if (attendes.contains(s)) {
+          // someone unavailable at time period
+          unavailableTimes.add(e.getWhen());
+          break;
+        }
+      }
+    }
+    return unavailableTimes; 
+  }
+
+  // finds unavailable times for list of optional attendees
+  public ArrayList<TimeRange> findUnavailableTimesOptionalAttendees(Collection<Event> events, Collection<String> optionalMembers) {
+    ArrayList<TimeRange> unavailableTimes = new ArrayList();
+    for (Event e : events) {
+      Set<String> attendes = e.getAttendees();
+      for (String s : optionalMembers) {
+        if (attendes.contains(s)) {
+          // someone is unavailable at time period
+          unavailableTimes.add(e.getWhen());
+          break;
+        }
+      }
+    }
+    return unavailableTimes; 
+  }
+
+  // find times where all mandatory members are free
+  public ArrayList<TimeRange> findAvalibaleTimesMandatoryMembers(ArrayList<TimeRange> unavailableTimes, MeetingRequest request) {
+    ArrayList<TimeRange> availableTimes = new ArrayList(); 
+    // stores starting time of available time range
+    int prevMeetingEnd = 0; 
+    // end of latest time period looked at 
+    int currMettingEnd = 0;
+
+    Collections.sort(unavailableTimes, TimeRange.ORDER_BY_START);
+    for (TimeRange unavailableTimeRange : unavailableTimes) {
+      // checks if meeting nested in other - ignore meeting in this case
+      if (unavailableTimeRange.end() > currMettingEnd) {
+        currMettingEnd = unavailableTimeRange.end();
+      } else {
+        continue;
+      }
+
+      // check time period long enough for meeting
+      if (unavailableTimeRange.start() - prevMeetingEnd < request.getDuration()) {
+        prevMeetingEnd = unavailableTimeRange.end(); 
+        continue; 
+      }
+
+      // add avaliable time
+      availableTimes.add(TimeRange.fromStartEnd(prevMeetingEnd, unavailableTimeRange.start(), false));
+      prevMeetingEnd = unavailableTimeRange.end();     
+    }
+
+    // add from start - end check
+    if (TimeRange.END_OF_DAY - prevMeetingEnd > request.getDuration()) {
+      availableTimes.add(TimeRange.fromStartEnd(prevMeetingEnd, TimeRange.END_OF_DAY, true));
+    } 
+    return availableTimes; 
+  }
+ 
+  // find times when all optional members are free
+  public ArrayList<TimeRange> findTimeWithOptionalMembers(ArrayList<TimeRange> availableTimes, ArrayList<TimeRange> unavailableTimesOptionalMembers) {
+    ArrayList<TimeRange> optionalMemberTimes = new ArrayList(); 
+    for (TimeRange availableTime : availableTimes) {
+      for (TimeRange unavailableOptionalTime : unavailableTimesOptionalMembers) {
+        if (!availableTime.overlaps(unavailableOptionalTime)) {
+          optionalMemberTimes.add(availableTime);
+        }
+      }
+    }
+    return optionalMemberTimes; 
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -39,7 +39,7 @@ public final class FindMeetingQuery {
     ArrayList<TimeRange> unavailableTimes = findUnavailableTimesMandatoryAttendees(events, mandatoryMembers);   
 
     // find available times from unavilable times from mandatory members
-    ArrayList<TimeRange> availableTimes = findAvalibaleTimesMandatoryMembers(unavailableTimes, request);
+    ArrayList<TimeRange> availableTimes = findAvailableTimesMandatoryMembers(unavailableTimes, request);
     
     // handle optional members if present
     if (optionalMembers.isEmpty()) {
@@ -91,7 +91,7 @@ public final class FindMeetingQuery {
   }
 
   // find times where all mandatory members are free
-  public ArrayList<TimeRange> findAvalibaleTimesMandatoryMembers(ArrayList<TimeRange> unavailableTimes, MeetingRequest request) {
+  public ArrayList<TimeRange> findAvailableTimesMandatoryMembers(ArrayList<TimeRange> unavailableTimes, MeetingRequest request) {
     ArrayList<TimeRange> availableTimes = new ArrayList(); 
     // stores starting time of available time range
     int prevMeetingEnd = 0; 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +44,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -270,5 +272,110 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-}
+ 
+@Test
+  public void optionalAttendeeUnavaliable() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times. Optional attendee has all day meeting 
 
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 0", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()),
+            Arrays.asList(PERSON_C)),
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee("Person C");
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+@Test
+  public void optionalAttendeeEarlyMeeting() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee("Person C");
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = 
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Assert.assertEquals(expected, actual);
+  }
+
+@Test
+  public void justEnoughRoomOptionalAttendee() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+            Arrays.asList(PERSON_C)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee("Person C");
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+@Test 
+  public void onlyOptionalAttendeesGaps() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee("Person A");
+    request.addOptionalAttendee("Person B");
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+@Test 
+  public void onlyOptionalAttendeesNoGaps() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_60_MINUTES);
+    request.addOptionalAttendee("Person A");
+    request.addOptionalAttendee("Person B");
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Algorithm to find available meeting times for list of mandatory and optional members given length of the meeting and other meetings scheduled for that day. Pass 21 tests given with file and 5 tests I wrote to verify optional members are added correctly. This is from the week 5 walkthrough. 